### PR TITLE
feat: implement Redis-based token bucket rate limiting for prediction…

### DIFF
--- a/src/services/predictionTaskService.ts
+++ b/src/services/predictionTaskService.ts
@@ -101,27 +101,29 @@ export const predictionTaskService = {
   async createJob(input: PredictionJobInput): Promise<PredictionJobCreated> {
     assertSupabase();
 
-    logger.info('Creating prediction job', { symbol: input.productName, location: input.location });
+    logger.info('Creating prediction job via Edge Function', { symbol: input.productName, location: input.location });
 
-    const { data, error } = await supabase
-      .from('price_predictions')
-      .insert({
-        symbol:          input.productName,
-        location:        input.location,
-        quantity:        input.quantity ?? '1 kg',
-        vendor_language: input.vendorLanguage ?? 'hindi',
-        buyer_message:   input.buyerMessage ?? null,
-        status:          'pending',
-      })
-      .select('job_id, status, created_at')
-      .single();
+    const { data, error } = await supabase.functions.invoke('create-prediction', {
+      body: {
+        productName: input.productName,
+        location: input.location,
+        quantity: input.quantity ?? '1 kg',
+        vendorLanguage: input.vendorLanguage ?? 'hindi',
+        buyerMessage: input.buyerMessage ?? null,
+      },
+    });
 
     if (error) {
-      logger.error('Failed to create prediction job', { error: error.message });
+      // Handle rate limit specifically
+      if (error.context?.status === 429 || error.message?.includes('429')) {
+        logger.warn('Rate limit exceeded for creating prediction job');
+        throw new Error('Too many requests. Please try again later.');
+      }
+      logger.error('Failed to create prediction job via Edge Function', { error: error.message });
       throw new Error(`Failed to create prediction job: ${error.message}`);
     }
 
-    logger.info('Prediction job created', { job_id: data.job_id });
+    logger.info('Prediction job created via Edge Function', { job_id: data.job_id });
     return {
       job_id:     data.job_id,
       status:     'pending',

--- a/supabase/functions/create-prediction/index.ts
+++ b/supabase/functions/create-prediction/index.ts
@@ -1,0 +1,123 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { Ratelimit } from 'npm:@upstash/ratelimit';
+import { Redis } from 'npm:@upstash/redis';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req: Request) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method Not Allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    // 1. Initialize Supabase client to extract user context
+    const authHeader = req.headers.get('Authorization');
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+
+    let userId: string | null = null;
+    if (authHeader) {
+      const supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
+        global: { headers: { Authorization: authHeader } },
+      });
+      const { data: { user }, error: authError } = await supabaseClient.auth.getUser();
+      if (!authError && user) {
+        userId = user.id;
+      }
+    }
+
+    // 2. Identify the client for Rate Limiting
+    // Prefer auth.uid() if present, fallback to IP address
+    const ipAddress = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || 'anonymous_ip';
+    const identifier = userId ? `user:${userId}` : `ip:${ipAddress}`;
+
+    // 3. Configure Token Bucket Rate Limiting
+    const rateLimitMax = parseInt(Deno.env.get('RATE_LIMIT_MAX') || '100', 10);
+    const redis = new Redis({
+      url: Deno.env.get('UPSTASH_REDIS_REST_URL')!,
+      token: Deno.env.get('UPSTASH_REDIS_REST_TOKEN')!,
+    });
+
+    const ratelimit = new Ratelimit({
+      redis,
+      limiter: Ratelimit.tokenBucket(rateLimitMax, '1 m', rateLimitMax),
+      analytics: false,
+      prefix: 'ratelimit:create_prediction',
+    });
+
+    const { success, limit, remaining, reset } = await ratelimit.limit(identifier);
+
+    // 4. Enforce Rate Limit
+    if (!success) {
+      return new Response(
+        JSON.stringify({
+          error: 'Too many requests. Please try again later.',
+          rateLimit: { limit, remaining, reset },
+        }),
+        {
+          status: 429,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // 5. Parse payload
+    const body = await req.json();
+    const { productName, location, quantity, vendorLanguage, buyerMessage } = body;
+
+    if (!productName || !location) {
+      return new Response(
+        JSON.stringify({ error: 'productName and location are required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // 6. Secure Insertion (bypass RLS using service_role key)
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+    const serviceClient = createClient(supabaseUrl, serviceRoleKey);
+
+    const { data, error } = await serviceClient
+      .from('price_predictions')
+      .insert({
+        symbol: productName,
+        location: location,
+        quantity: quantity || '1 kg',
+        vendor_language: vendorLanguage || 'hindi',
+        buyer_message: buyerMessage || null,
+        status: 'pending',
+        user_id: userId, // associate with user if authenticated
+      })
+      .select('job_id, created_at')
+      .single();
+
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 7. Success response
+    return new Response(JSON.stringify(data), {
+      status: 201,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error: unknown) {
+    const errMessage = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(JSON.stringify({ error: errMessage }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260622000000_revoke_insert_predictions.sql
+++ b/supabase/migrations/20260622000000_revoke_insert_predictions.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- Migration: Revoke INSERT on price_predictions
+-- Description: Drops the public INSERT policy to enforce that clients must
+-- route through the `create-prediction` Edge Function for rate limiting.
+-- =============================================================================
+
+-- Drop the existing INSERT policy that allows users to create jobs directly
+DROP POLICY IF EXISTS "Users can create prediction jobs" ON public.price_predictions;
+
+-- Note: RLS is already enabled and there are no other INSERT policies for
+-- anon or authenticated users. The service_role (used by the Edge Function)
+-- naturally bypasses RLS and can still perform INSERTs.


### PR DESCRIPTION
## Description
Implements a secure, server-side, Redis-based token bucket rate limiter for the prediction job creation endpoint to prevent resource abuse and exhaustion.

## Changes
- **Database/RLS:** Dropped direct public `INSERT` policy on `price_predictions`. Direct PostgREST API access is now blocked for `anon` and `authenticated` roles.
- **Edge Function:** Created `create-prediction` API Gateway using `@upstash/ratelimit` and `@upstash/redis` to handle token-bucket enforcement (max 100 req/min via `RATE_LIMIT_MAX`). Inserts data securely using the `service_role` key.
- **Frontend:** Updated `predictionTaskService.ts` to call the new Edge Function via `supabase.functions.invoke()` and added graceful error handling for HTTP 429 status codes.

## Env Variables Required
- `UPSTASH_REDIS_REST_URL`
- `UPSTASH_REDIS_REST_TOKEN`
- `RATE_LIMIT_MAX` (Optional)

## Testing Done
- Verified local edge function intercepts requests.
- Confirmed that rapid spamming triggers an HTTP 429 and displays the elegant UI error toast.
- Confirmed direct SQL inserts via PostgREST are successfully blocked by RLS.